### PR TITLE
Update HPX and Kokkos requirements 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,13 +11,32 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/hpx:dev
+    container: stellargroup/build_env:latest
 
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
       shell: bash
       run: |
+          mkdir -p /tmp/hpx
+          cd /tmp/hpx
+          git clone \
+              --branch master \
+              --single-branch \
+              --depth 1 \
+              https://github.com/STEllAR-GROUP/hpx.git
+          mkdir -p build
+          cd build
+          cmake \
+              ../hpx \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_UNITY_BUILD=ON \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_EXAMPLES=OFF \
+              -DHPX_WITH_NETWORKING=OFF
+          ninja install
+
           mkdir -p /tmp/kokkos
           cd /tmp/kokkos
           git clone \
@@ -30,7 +49,6 @@ jobs:
           cmake \
               ../kokkos \
               -GNinja \
-              -DCMAKE_CXX_FLAGS="-Werror" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DKokkos_ENABLE_HPX=ON \
               -DKokkos_ENABLE_HPX_ASYNC_DISPATCH=ON
@@ -42,6 +60,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_FLAGS="-Werror" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_KOKKOS_ENABLE_TESTS=ON
     - name: Build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2020-2022 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,13 +18,13 @@ jobs:
     - name: Install dependencies
       shell: bash
       run: |
-          mkdir -p /tmp/kokkos-develop
-          cd /tmp/kokkos-develop
+          mkdir -p /tmp/kokkos
+          cd /tmp/kokkos
           git clone \
-              --branch hpx-update-deprecations \
+              --branch develop \
               --single-branch \
               --depth 1 \
-              https://github.com/msimberg/kokkos.git
+              https://github.com/kokkos/kokkos.git
           mkdir -p build
           cd build
           cmake \

--- a/.jenkins/common/set_github_status.sh
+++ b/.jenkins/common/set_github_status.sh
@@ -21,4 +21,4 @@ curl --verbose \
     --url "https://api.github.com/repos/${commit_repo}/statuses/${commit_sha}" \
     --header 'Content-Type: application/json' \
     --header "authorization: Bearer ${github_token}" \
-    --data "{ \"state\": \"${commit_status}\", \"target_url\": \"https://cdash.cscs.ch/buildSummary.php?buildid=${build_id}\", \"description\": \"Jenkins\", \"context\": \"${context}/${configuration_name}\" }"
+    --data "{ \"state\": \"${commit_status}\", \"target_url\": \"https://cdash.cscs.ch/build/${build_id}\", \"description\": \"Jenkins\", \"context\": \"${context}/${configuration_name}\" }"

--- a/.jenkins/cscs/Jenkinsfile
+++ b/.jenkins/cscs/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-// Copyright (c) 2020 ETH Zurich
+// Copyright (c) 2020-2022 ETH Zurich
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -48,11 +48,11 @@ pipeline {
                     }
                     axis {
                          name 'hpx_version'
-                         values '1.7.0'
+                         values 'master'
                     }
                     axis {
                          name 'kokkos_version'
-                         values 'hpx-update-deprecations'
+                         values 'develop'
                     }
                     axis {
                          name 'future_type'

--- a/.jenkins/cscs/batch.sh
+++ b/.jenkins/cscs/batch.sh
@@ -39,7 +39,7 @@ git clone \
     --branch ${kokkos_version} \
     --single-branch \
     --depth 1 \
-    https://github.com/msimberg/kokkos.git /dev/shm/kokkos/src
+    https://github.com/kokkos/kokkos.git /dev/shm/kokkos/src
 cmake \
     -S /dev/shm/kokkos/src \
     -B /dev/shm/kokkos/build \

--- a/.jenkins/cscs/env-clang-cuda.sh
+++ b/.jenkins/cscs/env-clang-cuda.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2020-2022 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,10 +8,12 @@ export CRAYPE_LINK_TYPE=dynamic
 export APPS_ROOT="/apps/daint/SSL/HPX/packages"
 export CXX_STD="17"
 export HWLOC_ROOT="${APPS_ROOT}/hwloc-2.0.3-gcc-8.3.0"
+export BOOST_ROOT="${APPS_ROOT}/boost-1.75.0-gcc-10.1.0-c++17-debug/"
 
 module load daint-gpu
 module load cudatoolkit/11.0.2_3.38-8.1__g5b73779
-module load Boost/1.75.0-CrayCCE-20.11
+spack load cmake@3.18.6
+spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 export CRAYPE_LINK_TYPE=dynamic
-export CXX_STD="14"
+export CXX_STD="17"
 
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 ETH Zurich
+# Copyright (c) 2020-2022 ETH Zurich
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,10 +9,11 @@ export CXX_STD="17"
 
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu
-module switch gcc gcc/9.3.0
-module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
-module load Boost/1.75.0-CrayGNU-20.11
-module load hwloc/.2.0.3
+module load cudatoolkit
+module load Boost/1.78.0-CrayGNU-21.09
+module load hwloc/2.4.1
+spack load cmake@3.18.6
+spack load ninja@1.10.0
 
 export CXX=`which CC`
 export CC=`which cc`

--- a/.jenkins/cscs/env-gcc-cuda.sh
+++ b/.jenkins/cscs/env-gcc-cuda.sh
@@ -9,7 +9,7 @@ export CXX_STD="17"
 
 module load daint-gpu
 module switch PrgEnv-cray PrgEnv-gnu
-module load cudatoolkit
+module load cudatoolkit/11.2.0_3.39-2.1__gf93aa1c
 module load Boost/1.78.0-CrayGNU-21.09
 module load hwloc/2.4.1
 spack load cmake@3.18.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,8 @@ set(HPX_KOKKOS_VERSION_PATCH 1)
 set(HPX_KOKKOS_VERSION_STRING "${HPX_KOKKOS_VERSION_MAJOR}.${HPX_KOKKOS_VERSION_MINOR}.${HPX_KOKKOS_VERSION_PATCH}.")
 
 # Dependencies
-find_package(HPX 1.7.0 REQUIRED)
-find_package(Kokkos 3.4.99 REQUIRED)
+find_package(HPX 1.8.0 REQUIRED)
+find_package(Kokkos 3.5.99 REQUIRED)
 
 # Check that Kokkos and HPX options are consistent.
 kokkos_check(DEVICES HPX OPTIONS HPX_ASYNC_DISPATCH)

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ prioritize getting it fixed for you.
   with other execution spaces always block and return a ready future (where
   appropriate).
 - Not all HPX parallel algorithms can be used with the Kokkos executors.
-  Currently the only available algorithms are `hpx::for_each`, `hpx::for_loop`,
-  and `hpx::reduce`. `hpx::for_loop` only supports integer ranges (no
-  iterators) and no induction or reduction objects.
+  Currently the only available algorithms are `hpx::for_each`,
+  `hpx::experimental::for_loop`, and `hpx::reduce`.
+  `hpx::experimental::for_loop` only supports integer ranges (no iterators) and
+  no induction or reduction objects.
 - `Kokkos::View` construction and destruction (when reference count goes to
   zero) are generally blocking operations and this library does not currently
   try to solve this problem. Workarounds are: create all required views upfront

--- a/benchmarks/future_overheads.cpp
+++ b/benchmarks/future_overheads.cpp
@@ -8,10 +8,10 @@
 /// future.
 
 #include <Kokkos_Core.hpp>
-#include <hpx/chrono.hpp>
-#include <hpx/hpx_main.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
+#include <hpx/local/chrono.hpp>
+#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,time" << std::endl;
@@ -49,7 +49,7 @@ void test_future_then_async(ExecutionSpace const &inst) {
    }).get();
 }
 
-int main(int argc, char *argv[]) {
+int hpx_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -64,6 +64,11 @@ int main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
+  hpx::local::finalize();
 
   return 0;
+}
+
+int main(int argc, char *argv[]) {
+  return hpx::local::init(hpx_main, argc, argv);
 }

--- a/benchmarks/overheads.cpp
+++ b/benchmarks/overheads.cpp
@@ -14,12 +14,12 @@
 /// of multiple launches.
 
 #include <Kokkos_Core.hpp>
-#include <hpx/algorithm.hpp>
-#include <hpx/chrono.hpp>
 #include <hpx/config.hpp>
-#include <hpx/hpx_main.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/chrono.hpp>
+#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,vector_size,launches_"
@@ -172,7 +172,7 @@ void test_for_loop(ExecutionSpace const &inst, int const n,
   }
 }
 
-int main(int argc, char *argv[]) {
+int hpx_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -188,6 +188,11 @@ int main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
+  hpx::local::finalize();
 
   return 0;
+}
+
+int main(int argc, char *argv[]) {
+  return hpx::local::init(hpx_main, argc, argv);
 }

--- a/benchmarks/overheads_multi_instance.cpp
+++ b/benchmarks/overheads_multi_instance.cpp
@@ -8,11 +8,11 @@
 /// for all launches it uses the instances provided by kokkos_instance_helper.
 
 #include <Kokkos_Core.hpp>
-#include <hpx/algorithm.hpp>
-#include <hpx/chrono.hpp>
-#include <hpx/hpx_main.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/chrono.hpp>
+#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,vector_size,launches_"
@@ -150,7 +150,7 @@ void test_for_loop(hpx::kokkos::kokkos_instance_helper<ExecutionSpace> &h,
   }
 }
 
-int main(int argc, char *argv[]) {
+int hpx_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -167,6 +167,11 @@ int main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
+  hpx::local::finalize();
 
   return 0;
+}
+
+int main(int argc, char *argv[]) {
+  return hpx::local::init(hpx_main, argc, argv);
 }

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -10,11 +10,11 @@
 // https://www.cs.virginia.edu/stream/ref.html
 
 #include <Kokkos_Core.hpp>
-#include <hpx/algorithm.hpp>
-#include <hpx/chrono.hpp>
-#include <hpx/hpx_main.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
+#include <hpx/local/algorithm.hpp>
+#include <hpx/local/chrono.hpp>
+#include <hpx/local/init.hpp>
 
 using elem_type = double;
 using view_type = Kokkos::View<elem_type *>;
@@ -322,8 +322,6 @@ void test_stream(int repetitions, int size) {
   host_view_type bh = Kokkos::create_mirror_view(b);
   host_view_type ch = Kokkos::create_mirror_view(c);
 
-  double scalar = 3.0;
-
   for (int i = 0; i < repetitions; ++i) {
     init(a, b, c, ah, bh, ch);
     test_stream_kokkos_fence("kokkos_fence", a, b, c);
@@ -351,7 +349,7 @@ void test_stream(int repetitions, int size) {
   }
 }
 
-int main(int argc, char *argv[]) {
+int hpx_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -364,6 +362,11 @@ int main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
+  hpx::local::finalize();
 
   return 0;
+}
+
+int main(int argc, char *argv[]) {
+  return hpx::local::init(hpx_main, argc, argv);
 }

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -285,7 +285,7 @@ void test_stream_kokkos_async_future(std::string const &label, view_type a,
 
 // Synchronous HPX for_loop.
 template <typename Step> void test_stream_hpx_impl(Step step) {
-  hpx::for_loop(hpx::kokkos::kok, 0, step.a.extent(0), step);
+  hpx::experimental::for_loop(hpx::kokkos::kok, 0, step.a.extent(0), step);
 }
 
 void test_stream_hpx(std::string const &label, view_type a, view_type b,
@@ -298,8 +298,8 @@ void test_stream_hpx(std::string const &label, view_type a, view_type b,
 
 // Asynchronous HPX for_loop.
 template <typename Step> void test_stream_hpx_future_impl(Step step) {
-  hpx::for_loop(hpx::kokkos::kok(hpx::execution::task), 0, step.a.extent(0),
-                step)
+  hpx::experimental::for_loop(hpx::kokkos::kok(hpx::execution::task), 0,
+                              step.a.extent(0), step)
       .get();
 }
 
@@ -356,7 +356,7 @@ int hpx_main(int argc, char *argv[]) {
     hpx::kokkos::detail::polling_helper p;
 
     print_header();
-    for (int size = 1024; size <= (1024 << 17); size *= 2) {
+    for (int size = 1024; size <= (1024 << 11); size *= 2) {
       test_stream(10, size);
     }
   }

--- a/src/hpx/kokkos/hpx_algorithms_for_each.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_for_each.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2020 ETH Zurich
+//  Copyright (c) 2019-2022 ETH Zurich
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -110,8 +110,8 @@ hpx::shared_future<void> for_each_range_helper(char const *label,
 template <typename ExecutionPolicy, typename Iter, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::for_each_t, ExecutionPolicy &&policy, Iter first,
-                  Iter last, F &&f) {
+auto tag_invoke(hpx::for_each_t, ExecutionPolicy &&policy, Iter first,
+                Iter last, F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::for_each_helper(policy.label(), policy.executor().instance(),
                               first, last, std::forward<F>(f)));
@@ -121,8 +121,8 @@ auto tag_dispatch(hpx::for_each_t, ExecutionPolicy &&policy, Iter first,
 template <typename ExecutionPolicy, typename Range, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::ranges::for_each_t, ExecutionPolicy &&policy, Range &&r,
-                  F &&f) {
+auto tag_invoke(hpx::ranges::for_each_t, ExecutionPolicy &&policy, Range &&r,
+                F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::for_each_range_helper(
           policy.label(), policy.executor().instance(), std::forward<Range>(r),

--- a/src/hpx/kokkos/hpx_algorithms_for_loop.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_for_loop.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2020-2022 ETH Zurich
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -49,8 +49,8 @@ hpx::shared_future<void> for_loop_helper(char const *label,
 template <typename ExecutionPolicy, typename I, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::for_loop_t, ExecutionPolicy &&policy,
-                  typename std::decay<I>::type first, I last, F &&f) {
+auto tag_invoke(hpx::experimental::for_loop_t, ExecutionPolicy &&policy,
+                typename std::decay<I>::type first, I last, F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::for_loop_helper(policy.label(), policy.executor().instance(),
                               first, last, std::forward<F>(f)));
@@ -59,9 +59,9 @@ auto tag_dispatch(hpx::for_loop_t, ExecutionPolicy &&policy,
 template <typename ExecutionPolicy, typename I, std::size_t N, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::for_loop_t, ExecutionPolicy &&policy,
-                  Kokkos::Array<I, N> const &first,
-                  Kokkos::Array<I, N> const &last, F &&f) {
+auto tag_invoke(hpx::experimental::for_loop_t, ExecutionPolicy &&policy,
+                Kokkos::Array<I, N> const &first,
+                Kokkos::Array<I, N> const &last, F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::for_loop_helper(policy.label(), policy.executor().instance(),
                               first, last, std::forward<F>(f)));
@@ -70,9 +70,9 @@ auto tag_dispatch(hpx::for_loop_t, ExecutionPolicy &&policy,
 template <typename ExecutionPolicy, typename I, std::size_t N, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::for_loop_t, ExecutionPolicy &&policy,
-                  Kokkos::Array<I, N> const &first,
-                  std::initializer_list<I> last, F &&f) {
+auto tag_invoke(hpx::experimental::for_loop_t, ExecutionPolicy &&policy,
+                Kokkos::Array<I, N> const &first, std::initializer_list<I> last,
+                F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::for_loop_helper(policy.label(), policy.executor().instance(),
                               first, last, f));

--- a/src/hpx/kokkos/hpx_algorithms_reduce.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_reduce.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019-2020 ETH Zurich
+//  Copyright (c) 2019-2022 ETH Zurich
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -79,8 +79,8 @@ hpx::shared_future<T> reduce_helper(char const *label,
 template <typename ExecutionPolicy, typename Iter, typename T, typename F,
           typename Enable = std::enable_if_t<
               is_kokkos_execution_policy<std::decay_t<ExecutionPolicy>>::value>>
-auto tag_dispatch(hpx::reduce_t, ExecutionPolicy &&policy, Iter first,
-                  Iter last, T init, F &&f) {
+auto tag_invoke(hpx::reduce_t, ExecutionPolicy &&policy, Iter first, Iter last,
+                T init, F &&f) {
   return detail::get_policy_result<ExecutionPolicy>::call(
       detail::reduce_helper(policy.label(), policy.executor().instance(), first,
                             last, init, std::forward<F>(f)));

--- a/tests/parallel_algorithms.cpp
+++ b/tests/parallel_algorithms.cpp
@@ -224,7 +224,7 @@ template <typename Executor> void test_for_loop(Executor &&exec) {
   }
   Kokkos::deep_copy(for_loop_data, for_loop_data_host);
 
-  hpx::for_loop(
+  hpx::experimental::for_loop(
       hpx::kokkos::kok.on(exec).label("for_loop sync"), 0, n,
       KOKKOS_LAMBDA(int i) { for_loop_data(i) *= 2; });
 
@@ -234,7 +234,7 @@ template <typename Executor> void test_for_loop(Executor &&exec) {
     HPX_KOKKOS_DETAIL_TEST(for_loop_data_host(i) == 2 * i);
   }
 
-  auto f = hpx::for_loop(
+  auto f = hpx::experimental::for_loop(
       hpx::kokkos::kok(hpx::execution::task).on(exec).label("for_loop task"), 0,
       n, KOKKOS_LAMBDA(int i) { for_loop_data(i) *= 3; });
 
@@ -262,7 +262,7 @@ template <typename Executor> void test_for_loop(Executor &&exec) {
 
   using limit_type = Kokkos::Array<long, 2>;
 
-  hpx::for_loop(
+  hpx::experimental::for_loop(
       hpx::kokkos::kok.on(exec).label("for_loop sync md"), limit_type({0, 0}),
       limit_type({n, m}),
       KOKKOS_LAMBDA(long i, long j) { for_loop_data2(i, j) *= 2; });
@@ -275,7 +275,7 @@ template <typename Executor> void test_for_loop(Executor &&exec) {
     }
   }
 
-  auto f2 = hpx::for_loop(
+  auto f2 = hpx::experimental::for_loop(
       hpx::kokkos::kok(hpx::execution::task).on(exec).label("for_loop task md"),
       limit_type({0, 0}), limit_type({n, m}),
       KOKKOS_LAMBDA(long i, long j) { for_loop_data2(i, j) *= 3; });
@@ -303,7 +303,7 @@ void test_for_loop_default() {
   }
   Kokkos::deep_copy(for_loop_data, for_loop_data_host);
 
-  hpx::for_loop(
+  hpx::experimental::for_loop(
       hpx::kokkos::kok.label("for_loop sync default"), 0, n,
       KOKKOS_LAMBDA(int i) { for_loop_data(i) *= 2; });
 
@@ -313,7 +313,7 @@ void test_for_loop_default() {
     HPX_KOKKOS_DETAIL_TEST(for_loop_data_host(i) == 2 * i);
   }
 
-  auto f = hpx::for_loop(
+  auto f = hpx::experimental::for_loop(
       hpx::kokkos::kok(hpx::execution::task).label("for_loop task default"), 0,
       n, KOKKOS_LAMBDA(int i) { for_loop_data(i) *= 3; });
 
@@ -340,7 +340,7 @@ void test_for_loop_default() {
 
   using limit_type = Kokkos::Array<long, 2>;
 
-  hpx::for_loop(
+  hpx::experimental::for_loop(
       hpx::kokkos::kok.label("for_loop sync default md"), limit_type({0, 0}),
       limit_type({n, m}),
       KOKKOS_LAMBDA(long i, long j) { for_loop_data2(i, j) *= 2; });
@@ -353,7 +353,7 @@ void test_for_loop_default() {
     }
   }
 
-  auto f2 = hpx::for_loop(
+  auto f2 = hpx::experimental::for_loop(
       hpx::kokkos::kok(hpx::execution::task).label("for_loop task default md"),
       limit_type({0, 0}), limit_type({n, m}),
       KOKKOS_LAMBDA(long i, long j) { for_loop_data2(i, j) *= 3; });

--- a/tests/policy.cpp
+++ b/tests/policy.cpp
@@ -13,7 +13,7 @@
 int main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
-  auto p1 = hpx::kokkos::kok;
+  [[maybe_unused]] auto p1 = hpx::kokkos::kok;
   static_assert(std::is_same<std::decay<decltype(p1.executor())>::type,
                              hpx::kokkos::default_executor>::value,
                 "kok executor should be default_executor");

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -32,10 +32,13 @@ int report_errors() {
   if (tests_done == 0) {
     std::cerr << "No tests run. Did you forget to add tests?" << std::endl;
     return 1;
+  } else if (tests_failed == 0) {
+    std::cerr << "All tests passed (" << tests_done << " tests run).";
+    return 0;
   } else {
     std::cerr << tests_failed << "/" << tests_done << " test"
               << (tests_done == 1 ? "" : "s") << " failed." << std::endl;
-    return tests_failed > 0;
+    return 1;
   }
 }
 } // namespace detail


### PR DESCRIPTION
- Require HPX 1.8.0 (or master) and Kokkos 3.5.99 (soon 3.6.0, or develop).
- Revert back the customizations to use `tag_invoke` (instead of `tag_dispatch`).
- Use local headers and runtime in benchmarks.

Edit: This will also become the 0.3.0 release.