### PR TITLE
Add get_future member method for convenience

### DIFF
--- a/src/hpx/kokkos/executors.hpp
+++ b/src/hpx/kokkos/executors.hpp
@@ -93,6 +93,11 @@ public:
         })};
   }
 
+  hpx::shared_future<void> get_future() {
+    return detail::get_future<typename std::decay<ExecutionSpace>::type>::call(
+        std::forward<ExecutionSpace>(inst));
+  }
+
   template <typename Parameters, typename F>
   constexpr std::size_t get_chunk_size(Parameters &&params, F &&f,
                                        std::size_t cores,


### PR DESCRIPTION
This PR simply adds a ```get_future``` member method to the executors to make them more compatible with the ```hpx::cuda::experimental::cuda_executor```.

 As for my use-case: I have some templated functions that call executor.get_future(). Originally, this was developed to be used with the HPX CUDA/HIP executors (which already have the get_future member method), but I would like that method to simply work both with the Kokkos- and with the CUDA/HIP HPX executors without changing too much! Hence this small addition to hpx-kokkos!