### PR TITLE
Add missing include to `instance_helper.hpp`

### DIFF
--- a/src/hpx/kokkos/instance_helper.hpp
+++ b/src/hpx/kokkos/instance_helper.hpp
@@ -13,6 +13,8 @@
 #include <hpx/kokkos/executors.hpp>
 #include <hpx/kokkos/make_instance.hpp>
 
+#include <hpx/local/runtime.hpp>
+
 #include <Kokkos_Core.hpp>
 
 namespace hpx {


### PR DESCRIPTION
The runtime include is required for `get_num_worker_threads`.