### PR TITLE
Add experimental sycl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,22 @@ else()
   endif()
 endif()
 
+if(Kokkos_ENABLE_SYCL)
+  if(NOT HPX_WITH_SYCL)
+    message(FATAL_ERROR "Kokkos was built with SYCL support, HPX was not")
+  endif()
+else()
+  if(HPX_WITH_SYCL)
+    message(FATAL_ERROR "HPX was built with SYCL support, Kokkos was not")
+  endif()
+endif()
+
 if(HPX_WITH_HIP OR Kokkos_ENABLE_HIP)
   message(WARNING "HIP support in experimental in HPX, Kokkos, and HPX-Kokkos")
+endif()
+
+if(HPX_WITH_SYCL OR Kokkos_ENABLE_SYCL)
+  message(WARNING "SYCL support in experimental in HPX, Kokkos, and HPX-Kokkos")
 endif()
 
 # Main targets provided by this project

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ class default_host_executor;
 // The following are conditionally defined
 class cuda_executor;
 class hip_executor;
+class sycl_executor;
 class hpx_executor;
 class openmp_executor;
 class rocm_executor;
@@ -113,7 +114,7 @@ prioritize getting it fixed for you.
 
 - Compilation with `nvcc` is likely not to work. Prefer `clang` for compiling
   CUDA code.
-- Only the HPX and CUDA execution spaces are asynchronous. Parallel algorithms
+- Only the HPX, CUDA, HIP and SYCL execution spaces are asynchronous. Parallel algorithms
   with other execution spaces always block and return a ready future (where
   appropriate).
 - Not all HPX parallel algorithms can be used with the Kokkos executors.

--- a/src/hpx/kokkos/detail/polling_helper.hpp
+++ b/src/hpx/kokkos/detail/polling_helper.hpp
@@ -11,16 +11,22 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#if defined(HPX_HAVE_COMPUTE)
+#if defined(HPX_HAVE_CUDA) || defined(HPX_HAVE_HIP)
 #include <hpx/modules/async_cuda.hpp>
+#endif
+#if defined(HPX_HAVE_SYCL)
+#include <hpx/modules/async_sycl.hpp>
 #endif
 
 namespace hpx {
 namespace kokkos {
 namespace detail {
 struct polling_helper {
-#if defined(HPX_HAVE_COMPUTE) && (HPX_KOKKOS_CUDA_FUTURE_TYPE == 0)
+#if (defined(HPX_HAVE_CUDA) || defined(HPX_HAVE_HIP)) && (HPX_KOKKOS_CUDA_FUTURE_TYPE == 0)
   hpx::cuda::experimental::enable_user_polling p;
+#endif
+#if defined(HPX_HAVE_SYCL)
+  hpx::sycl::experimental::enable_user_polling p;
 #endif
 };
 } // namespace detail

--- a/src/hpx/kokkos/executors.hpp
+++ b/src/hpx/kokkos/executors.hpp
@@ -87,7 +87,7 @@ public:
         KOKKOS_LAMBDA(int i) {
           HPX_KOKKOS_DETAIL_LOG("bulk_async_execute i = %d", i);
           using index_pack_type =
-              typename hpx::util::detail::fused_index_pack<decltype(
+              typename hpx::detail::fused_index_pack<decltype(
                   ts_pack)>::type;
           detail::invoke_helper(index_pack_type{}, f, *(b + i), ts_pack);
         })};

--- a/src/hpx/kokkos/executors.hpp
+++ b/src/hpx/kokkos/executors.hpp
@@ -121,6 +121,10 @@ using cuda_executor = executor<Kokkos::Cuda>;
 using hip_executor = executor<Kokkos::Experimental::HIP>;
 #endif
 
+#if defined(KOKKOS_ENABLE_SYCL)
+using sycl_executor = executor<Kokkos::Experimental::SYCL>;
+#endif
+
 #if defined(KOKKOS_ENABLE_HPX)
 using hpx_executor = executor<Kokkos::Experimental::HPX>;
 #endif

--- a/src/hpx/kokkos/future.hpp
+++ b/src/hpx/kokkos/future.hpp
@@ -15,8 +15,11 @@
 #include <hpx/config.hpp>
 #include <hpx/local/future.hpp>
 
-#if defined(HPX_HAVE_COMPUTE)
+#if defined(HPX_HAVE_CUDA) || defined(HPX_HAVE_HIP)
 #include <hpx/modules/async_cuda.hpp>
+#endif
+#if defined(HPX_HAVE_SYCL)
+#include <hpx/modules/async_sycl.hpp>
 #endif
 
 #include <Kokkos_Core.hpp>
@@ -73,6 +76,16 @@ template <> struct get_future<Kokkos::Experimental::HIP> {
 #else
 #error "HPX_KOKKOS_CUDA_FUTURE_TYPE is invalid (must be callback or event)"
 #endif
+  }
+};
+#endif
+
+#if defined(KOKKOS_ENABLE_SYCL)
+template <> struct get_future<Kokkos::Experimental::SYCL> {
+  template <typename E> static hpx::shared_future<void> call(E &&inst) {
+    HPX_KOKKOS_DETAIL_LOG("getting future from SYCL queue %p", &(inst.sycl_queue()));
+    auto fut = hpx::sycl::experimental::detail::get_future(inst.sycl_queue());
+    return fut ;
   }
 };
 #endif

--- a/src/hpx/kokkos/hpx_algorithms_reduce.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_reduce.hpp
@@ -45,6 +45,13 @@ template <> struct reduce_result_space<Kokkos::Experimental::HIP> {
 };
 #endif
 
+#if defined(KOKKOS_ENABLE_SYCL)
+// Needs to be a SYCL host space for async deep copies
+template <> struct reduce_result_space<Kokkos::Experimental::SYCL> {
+  using type = Kokkos::Experimental::SYCLHostUSMSpace;
+};
+#endif
+
 template <typename ExecutionSpace>
 using reduce_result_space_t =
     typename reduce_result_space<ExecutionSpace>::type;


### PR DESCRIPTION
This PR integrates asynchronous HPX futures for kernel launches using the Kokkos SYCL execution space. Mostly it just integrates the new ```get_future(sycl_queue)``` HPX functionality, makes sure that the correct result space is used for reduce operations and lastly, makes everything compile with SYCL in the first place.

For testing it, I used OneAPI (using dpcpp version 2022.2.1.20221020) on my integrated Iris Xe GPU and https://github.com/kokkos/kokkos/commit/61d7db55fceac3318c987a291f77b844fd94c165. Without the ```get_future(sycl_queue)``` integration, the asynchrony tests would fail, with it everything passes.
Though, to run the tests on the given Intel GPU in the first place, one needs to enable fp64 emulation like this:
 ```export OverrideDefaultFP64Settings=1 && export IGC_EnableDPEmulation=1```

This PR depends on https://github.com/STEllAR-GROUP/hpx/pull/6085 to be merged first!