### PR TITLE
Remove `rocm_executor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ class cuda_executor;
 class hip_executor;
 class hpx_executor;
 class openmp_executor;
-class rocm_executor;
 class serial_executor;
 }}
 ```

--- a/src/hpx/kokkos/executors.hpp
+++ b/src/hpx/kokkos/executors.hpp
@@ -128,10 +128,6 @@ using hpx_executor = executor<Kokkos::Experimental::HPX>;
 using openmp_executor = executor<Kokkos::OpenMP>;
 #endif
 
-#if defined(KOKKOS_ENABLE_ROCM)
-using rocm_executor = executor<Kokkos::ROCm>;
-#endif
-
 #if defined(KOKKOS_ENABLE_SERIAL)
 using serial_executor = executor<Kokkos::Serial>;
 #endif


### PR DESCRIPTION
The ROCm execution space has been removed from Kokkos a long time ago.