### PR TITLE
Relax required Kokkos version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(HPX_KOKKOS_VERSION_STRING "${HPX_KOKKOS_VERSION_MAJOR}.${HPX_KOKKOS_VERSION_
 find_package(HPX 1.8.1 REQUIRED)
 # TODO: The version requirement needs to be bumped once
 # https://github.com/kokkos/kokkos/pull/5628 is merged and released.
-find_package(Kokkos 3.7.99 REQUIRED)
+find_package(Kokkos 3.6.01 REQUIRED)
 
 if(Kokkos_ENABLE_CUDA)
   kokkos_check(OPTIONS CUDA_LAMBDA CUDA_LAMBDA)


### PR DESCRIPTION
I would like to reduce the required Kokkos version to 3.6.01. Particularly, this allows me to use some older ROCm versions on a Jenkins node for automatic performance and verification tests with Octo-Tiger. From what I can see there, at least for AMD GPU builds, the old Kokkos version also works flawlessly with Octo-Tiger and allows me to also run additional tests/comparisons with ROCm 4.5 (instead of just ROCm >= 5). 