### PR TITLE
Fix name clash

### DIFF
--- a/src/hpx/kokkos/detail/polling_helper.hpp
+++ b/src/hpx/kokkos/detail/polling_helper.hpp
@@ -26,7 +26,7 @@ struct polling_helper {
   hpx::cuda::experimental::enable_user_polling p;
 #endif
 #if defined(HPX_HAVE_SYCL)
-  hpx::sycl::experimental::enable_user_polling p;
+  hpx::sycl::experimental::enable_user_polling p_sycl;
 #endif
 };
 } // namespace detail


### PR DESCRIPTION
There is a name clash with the polling helpers in case HPX is built with both CUDA and SYCL support. This PR merely corrects this small oversight.