### PR TITLE
Improve CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     container: stellargroup/build_env:latest
 
+    strategy:
+      matrix:
+        hpx_version: ["1.8.1", "v1.9.0", "v1.10.0"]
+        kokkos_version: ["3.6.00", "4.0.00"]
+
     steps:
     - uses: actions/checkout@v2
     - name: Update apt repositories for ccache
@@ -24,14 +29,14 @@ jobs:
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ccache-linux
+        key: ccache-linux-${{ matrix.hpx_version }}-${{ matrix.kokkos_version }}
     - name: Install HPX
       shell: bash
       run: |
           mkdir -p /tmp/hpx
           cd /tmp/hpx
           git clone \
-              --branch v1.9.0 \
+              --branch ${{ matrix.hpx_version }} \
               --single-branch \
               --depth 1 \
               https://github.com/STEllAR-GROUP/hpx.git
@@ -53,7 +58,7 @@ jobs:
           mkdir -p /tmp/kokkos
           cd /tmp/kokkos
           git clone \
-              --branch 4.5.00 \
+              --branch ${{ matrix.kokkos_version }} \
               --single-branch \
               --depth 1 \
               https://github.com/kokkos/kokkos.git

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,8 @@ jobs:
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DKokkos_ENABLE_HPX=ON
+              -DKokkos_ENABLE_HPX=ON \
+              -DKokkos_ENABLE_HPX_ASYNC_DISPATCH=ON
           ninja install
     - name: Configure
       shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
+    - name: Install HPX
       shell: bash
       run: |
           mkdir -p /tmp/hpx
@@ -40,7 +40,9 @@ jobs:
               -DHPX_WITH_EXAMPLES=OFF \
               -DHPX_WITH_NETWORKING=OFF
           ninja install
-
+    - name: Install Kokkos
+      shell: bash
+      run: |
           mkdir -p /tmp/kokkos
           cd /tmp/kokkos
           git clone \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir -p /tmp/kokkos
           cd /tmp/kokkos
           git clone \
-              --branch develop \
+              --branch 4.5.00 \
               --single-branch \
               --depth 1 \
               https://github.com/kokkos/kokkos.git

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Update apt repositories for ccache
+      run: apt update
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ccache-linux
     - name: Install HPX
       shell: bash
       run: |
@@ -34,6 +40,7 @@ jobs:
           cmake \
               ../hpx \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_WITH_UNITY_BUILD=ON \
               -DHPX_WITH_MALLOC=system \
@@ -55,6 +62,7 @@ jobs:
           cmake \
               ../kokkos \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_BUILD_TYPE=Debug \
               -DKokkos_ENABLE_HPX=ON
           ninja install
@@ -65,6 +73,7 @@ jobs:
               . \
               -Bbuild \
               -GNinja \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_FLAGS="-Werror" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_KOKKOS_ENABLE_TESTS=ON

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,7 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_FLAGS="-Werror" \
+              -DCMAKE_CXX_FLAGS="-Werror -Wno-error=#warnings" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_KOKKOS_ENABLE_TESTS=ON
     - name: Build


### PR DESCRIPTION
- Test with multiple versions of HPX and Kokkos
  - I've left out Kokkos 4.5.00 since it requires #25 to actually build. I would suggest to add it in #25.
- Use ccache
- Disables `#warning` as error, from HPX deprecation warnings (of includes). This should also be updated separately.