### PR TITLE
Don't use deprecated headers from HPX

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,6 +21,13 @@ jobs:
       matrix:
         hpx_version: ["1.8.1", "v1.9.0", "v1.10.0"]
         kokkos_version: ["3.6.00", "4.0.00"]
+        include:
+          - hpx_version: "v1.10.0"
+            kokkos_version: "3.6.00"
+            cxxflags: "-Wno-error=#warnings"
+          - hpx_version: "v1.10.0"
+            kokkos_version: "4.0.00"
+            cxxflags: "-Wno-error=#warnings"
 
     steps:
     - uses: actions/checkout@v2
@@ -80,7 +87,7 @@ jobs:
               -Bbuild \
               -GNinja \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_FLAGS="-Werror -Wno-error=#warnings" \
+              -DCMAKE_CXX_FLAGS="-Werror ${{ matrix.cxxflags }}" \
               -DCMAKE_BUILD_TYPE=Debug \
               -DHPX_KOKKOS_ENABLE_TESTS=ON
     - name: Build

--- a/benchmarks/future_overheads.cpp
+++ b/benchmarks/future_overheads.cpp
@@ -49,7 +49,7 @@ void test_future_then_async(ExecutionSpace const &inst) {
    }).get();
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -70,5 +70,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/benchmarks/future_overheads.cpp
+++ b/benchmarks/future_overheads.cpp
@@ -8,10 +8,10 @@
 /// future.
 
 #include <Kokkos_Core.hpp>
+#include <hpx/chrono.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,time" << std::endl;
@@ -64,11 +64,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return 0;
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/benchmarks/overheads.cpp
+++ b/benchmarks/overheads.cpp
@@ -172,7 +172,7 @@ void test_for_loop(ExecutionSpace const &inst, int const n,
   }
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -194,5 +194,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/benchmarks/overheads.cpp
+++ b/benchmarks/overheads.cpp
@@ -14,12 +14,12 @@
 /// of multiple launches.
 
 #include <Kokkos_Core.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/chrono.hpp>
 #include <hpx/config.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,vector_size,launches_"
@@ -188,11 +188,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return 0;
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/benchmarks/overheads_multi_instance.cpp
+++ b/benchmarks/overheads_multi_instance.cpp
@@ -150,7 +150,7 @@ void test_for_loop(hpx::kokkos::kokkos_instance_helper<ExecutionSpace> &h,
   }
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -173,5 +173,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/benchmarks/overheads_multi_instance.cpp
+++ b/benchmarks/overheads_multi_instance.cpp
@@ -8,11 +8,11 @@
 /// for all launches it uses the instances provided by kokkos_instance_helper.
 
 #include <Kokkos_Core.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/chrono.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 void print_header() {
   std::cout << "test_name,execution_space,subtest_name,vector_size,launches_"
@@ -167,11 +167,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return 0;
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -10,11 +10,11 @@
 // https://www.cs.virginia.edu/stream/ref.html
 
 #include <Kokkos_Core.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/chrono.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 using elem_type = double;
 using view_type = Kokkos::View<elem_type *>;
@@ -362,11 +362,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return 0;
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/benchmarks/stream.cpp
+++ b/benchmarks/stream.cpp
@@ -349,7 +349,7 @@ void test_stream(int repetitions, int size) {
   }
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -368,5 +368,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/src/hpx/kokkos/executors.hpp
+++ b/src/hpx/kokkos/executors.hpp
@@ -13,9 +13,9 @@
 #include <hpx/kokkos/kokkos_algorithms.hpp>
 #include <hpx/kokkos/make_instance.hpp>
 
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/numeric.hpp>
-#include <hpx/local/tuple.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/numeric.hpp>
+#include <hpx/tuple.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/future.hpp
+++ b/src/hpx/kokkos/future.hpp
@@ -13,7 +13,7 @@
 #include <hpx/kokkos/detail/logging.hpp>
 
 #include <hpx/config.hpp>
-#include <hpx/local/future.hpp>
+#include <hpx/future.hpp>
 
 #if defined(HPX_HAVE_CUDA) || defined(HPX_HAVE_HIP)
 #include <hpx/modules/async_cuda.hpp>

--- a/src/hpx/kokkos/hpx_algorithms_for_each.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_for_each.hpp
@@ -11,8 +11,8 @@
 #include <hpx/kokkos/detail/logging.hpp>
 #include <hpx/kokkos/policy.hpp>
 
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/functional.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/functional.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/hpx_algorithms_for_loop.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_for_loop.hpp
@@ -11,7 +11,7 @@
 #include <hpx/kokkos/detail/logging.hpp>
 #include <hpx/kokkos/policy.hpp>
 
-#include <hpx/local/algorithm.hpp>
+#include <hpx/algorithm.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/hpx_algorithms_reduce.hpp
+++ b/src/hpx/kokkos/hpx_algorithms_reduce.hpp
@@ -11,8 +11,8 @@
 #include <hpx/kokkos/detail/logging.hpp>
 #include <hpx/kokkos/policy.hpp>
 
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/functional.hpp>
+#include <hpx/algorithm.hpp>
+#include <hpx/functional.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/instance_helper.hpp
+++ b/src/hpx/kokkos/instance_helper.hpp
@@ -13,7 +13,7 @@
 #include <hpx/kokkos/executors.hpp>
 #include <hpx/kokkos/make_instance.hpp>
 
-#include <hpx/local/runtime.hpp>
+#include <hpx/runtime.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/kokkos_algorithms.hpp
+++ b/src/hpx/kokkos/kokkos_algorithms.hpp
@@ -10,7 +10,7 @@
 #include <hpx/kokkos/detail/logging.hpp>
 #include <hpx/kokkos/future.hpp>
 
-#include <hpx/local/future.hpp>
+#include <hpx/future.hpp>
 
 #include <Kokkos_Core.hpp>
 

--- a/src/hpx/kokkos/policy.hpp
+++ b/src/hpx/kokkos/policy.hpp
@@ -12,8 +12,8 @@
 #include <hpx/kokkos/detail/logging.hpp>
 #include <hpx/kokkos/executors.hpp>
 
-#include <hpx/local/execution.hpp>
-#include <hpx/local/future.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
 
 namespace hpx {
 namespace kokkos {

--- a/tests/asynchrony.cpp
+++ b/tests/asynchrony.cpp
@@ -12,11 +12,11 @@
 
 #include "test.hpp"
 
+#include <hpx/algorithm.hpp>
+#include <hpx/chrono.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 template <typename ExecutionSpace>
 void test_kokkos_plain(ExecutionSpace &&inst, int const n,
@@ -225,11 +225,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/asynchrony.cpp
+++ b/tests/asynchrony.cpp
@@ -206,7 +206,7 @@ void test_default(int const n, int const repetitions) {
   test_hpx_async(hpx::kokkos::executor<>(), n, repetitions);
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   int const n = 10000000;
   int const repetitions = 10;
 
@@ -231,5 +231,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/executors.cpp
+++ b/tests/executors.cpp
@@ -8,10 +8,10 @@
 
 #include "test.hpp"
 
+#include <hpx/execution.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/execution.hpp>
-#include <hpx/local/init.hpp>
 
 #include <atomic>
 #include <cassert>
@@ -97,11 +97,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/executors.cpp
+++ b/tests/executors.cpp
@@ -82,7 +82,7 @@ template <typename Executor> void test(Executor &&exec) {
   }
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -103,5 +103,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/executors_instance_mode.cpp
+++ b/tests/executors_instance_mode.cpp
@@ -87,7 +87,7 @@ template <> void test<Kokkos::Experimental::HIP>() {
 }
 #endif
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -105,5 +105,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/executors_instance_mode.cpp
+++ b/tests/executors_instance_mode.cpp
@@ -9,10 +9,10 @@
 
 #include "test.hpp"
 
+#include <hpx/execution.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/execution.hpp>
-#include <hpx/local/init.hpp>
 
 #include <atomic>
 #include <cassert>
@@ -99,11 +99,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/kokkos_async_parallel.cpp
+++ b/tests/kokkos_async_parallel.cpp
@@ -8,10 +8,10 @@
 
 #include "test.hpp"
 
+#include <hpx/chrono.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/chrono.hpp>
-#include <hpx/local/init.hpp>
 
 #include <string>
 
@@ -120,11 +120,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/kokkos_async_parallel.cpp
+++ b/tests/kokkos_async_parallel.cpp
@@ -105,7 +105,7 @@ template <typename ExecutionSpace> void test(ExecutionSpace &&inst) {
   test_parallel_scan(inst);
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -126,5 +126,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/linking.cpp
+++ b/tests/linking.cpp
@@ -9,15 +9,15 @@
 
 #include "test.hpp"
 
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
-#include <hpx/local/init.hpp>
 
 int hpx_main(int argc, char *argv[]) {
   HPX_KOKKOS_DETAIL_TEST(true);
-  hpx::local::finalize();
+  hpx::finalize();
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/linking.cpp
+++ b/tests/linking.cpp
@@ -12,12 +12,12 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   HPX_KOKKOS_DETAIL_TEST(true);
   hpx::finalize();
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/parallel_algorithms.cpp
+++ b/tests/parallel_algorithms.cpp
@@ -453,7 +453,7 @@ void test_default() {
   test_reduce_default();
 }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -475,5 +475,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }

--- a/tests/parallel_algorithms.cpp
+++ b/tests/parallel_algorithms.cpp
@@ -8,11 +8,11 @@
 
 #include "test.hpp"
 
+#include <hpx/algorithm.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/init.hpp>
-#include <hpx/local/numeric.hpp>
+#include <hpx/numeric.hpp>
 
 template <typename Executor> void test_for_each(Executor &&exec) {
   int const n = 43;
@@ -469,11 +469,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/view_iterator.cpp
+++ b/tests/view_iterator.cpp
@@ -8,10 +8,10 @@
 
 #include "test.hpp"
 
+#include <hpx/algorithm.hpp>
+#include <hpx/hpx_init.hpp>
 #include <hpx/kokkos.hpp>
 #include <hpx/kokkos/detail/polling_helper.hpp>
-#include <hpx/local/algorithm.hpp>
-#include <hpx/local/init.hpp>
 
 template <typename Executor> void test_for_each(Executor &&exec) {
   int const n = 43;
@@ -77,11 +77,11 @@ int hpx_main(int argc, char *argv[]) {
   }
 
   Kokkos::finalize();
-  hpx::local::finalize();
+  hpx::finalize();
 
   return hpx::kokkos::detail::report_errors();
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::local::init(hpx_main, argc, argv);
+  return hpx::init(hpx_main, argc, argv);
 }

--- a/tests/view_iterator.cpp
+++ b/tests/view_iterator.cpp
@@ -62,7 +62,7 @@ template <typename Executor> void test_for_each(Executor &&exec) {
 
 template <typename Executor> void test(Executor &&exec) { test_for_each(exec); }
 
-int hpx_main(int argc, char *argv[]) {
+int test_main(int argc, char *argv[]) {
   Kokkos::initialize(argc, argv);
 
   {
@@ -83,5 +83,5 @@ int hpx_main(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-  return hpx::init(hpx_main, argc, argv);
+  return hpx::init(test_main, argc, argv);
 }


### PR DESCRIPTION
- Don't use deprecated `hpx/local/...` headers
- Rename test entry points to `test_main` due to HPX in earlier versions declaring multiple overloads of `hpx_main`
- Only use `-Wno-error=#warnings` on specific configurations that require it