### PR TITLE
Change SYCL namespace from cl::sycl to ::sycl

### DIFF
--- a/src/hpx/kokkos/make_instance.hpp
+++ b/src/hpx/kokkos/make_instance.hpp
@@ -55,8 +55,8 @@ template <>
 inline Kokkos::Experimental::SYCL
 make_independent_execution_space_instance<Kokkos::Experimental::SYCL>() {
   try {
-    cl::sycl::queue q(cl::sycl::default_selector{},
-                cl::sycl::property::queue::in_order{});
+    ::sycl::queue q(::sycl::default_selector_v,
+                ::sycl::property::queue::in_order{});
     return Kokkos::Experimental::SYCL{q};
   } catch (exception const &e) {
     HPX_THROW_EXCEPTION(


### PR DESCRIPTION
In STEllAR-GROUP/hpx#6679 we moved from the cl::sycl namespace to the sycl namespace to fix some deprecation warnings.

Accordingly, we need to do the same in hpx-kokkos which this PR does (without it, we cannot actually build with SYCL right now, as the header with the cl:: namespace is not included anymore).